### PR TITLE
Add foreign key functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "license": "MIT",
     "name": "ruckusing/ruckusing-migrations",
     "require": {
-        "php": ">=5.2.0"
+        "php": ">=5.2.0",
+        "doctrine/inflector": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -874,7 +874,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
     public function remove_foreign_key($table_name, $key_name)
     {
 
-        if (empty($orig_table_name)) {
+        if (empty($table_name)) {
             throw new Ruckusing_Exception(
                 "Missing table name parameter",
                 Ruckusing_Exception::INVALID_ARGUMENT
@@ -888,7 +888,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
         }
 
         $sql = sprintf("ALTER TABLE %s DROP FOREIGN KEY %s",
-            $this->identifier($orig_table_name),
+            $this->identifier($table_name),
             $this->identifier($key_name)
        );
 

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -1,5 +1,6 @@
 <?php
 
+use Doctrine\Common\Inflector\Inflector;
 /**
  * Ruckusing
  *

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -854,7 +854,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
             $on_update = '';
         }
         if (is_array($options) && array_key_exists('on_delete', $options)) {
-            $on_delete = " ON DELETE" . $options['on_delete'];
+            $on_delete = " ON DELETE " . $options['on_delete'];
         } else {
             $on_delete = '';
         }

--- a/lib/Ruckusing/Migration/Base.php
+++ b/lib/Ruckusing/Migration/Base.php
@@ -220,16 +220,18 @@ class Ruckusing_Migration_Base
     }
 
     /**
-     * Adds a foreign key
-     * @param unknown $orig_table_name
-     * @param unknown $dest_table_name
-     * @param unknown $options.
+     * Adds a foreign key on the given origin table to the given destination table
+     * @param string $orig_table_name The origin table name
+     * @param string $dest_table_name The destination table name
+     * @param array $options
      *
      * Possible options are:
-     *  - orig_column_name: The column name from the origin table (defaults to "destTable_id")
+     *  - orig_column_name: The column name from the origin table (defaults to "dest_table_id")
      *  - dest_column_name: The column name in the destination_table (defaults to "id")
+     *  - constraint_name: The anme of the foreign key (defaults to "name_of_the_origin_table_name_of_the_origin_column_fk")
      *  - on_update: action on update. example: RESTRICT, CASCADE
      *  - on_delete: action on delete. example: RESTRICT, CASCADE
+     *
      * @return boolean
      */
 

--- a/lib/Ruckusing/Migration/Base.php
+++ b/lib/Ruckusing/Migration/Base.php
@@ -228,7 +228,7 @@ class Ruckusing_Migration_Base
      * Possible options are:
      *  - orig_column_name: The column name from the origin table (defaults to "dest_table_id")
      *  - dest_column_name: The column name in the destination_table (defaults to "id")
-     *  - constraint_name: The anme of the foreign key (defaults to "name_of_the_origin_table_name_of_the_origin_column_fk")
+     *  - constraint_name: The name of the foreign key (defaults to "name_of_the_origin_table_name_of_the_origin_column_fk")
      *  - on_update: action on update. example: RESTRICT, CASCADE
      *  - on_delete: action on delete. example: RESTRICT, CASCADE
      *
@@ -244,6 +244,8 @@ class Ruckusing_Migration_Base
      * Removes a foreign key
      * @param unknown $table_name
      * @param unknown $key_name
+     *
+     * @todo: allow same params as add_foreign_key to autogenerate the foreign key name
      */
 
     public function remove_foreign_key($table_name, $key_name)

--- a/lib/Ruckusing/Migration/Base.php
+++ b/lib/Ruckusing/Migration/Base.php
@@ -220,6 +220,36 @@ class Ruckusing_Migration_Base
     }
 
     /**
+     * Adds a foreign key
+     * @param unknown $orig_table_name
+     * @param unknown $dest_table_name
+     * @param unknown $options.
+     *
+     * Possible options are:
+     *  - orig_column_name: The column name from the origin table (defaults to "destTable_id")
+     *  - dest_column_name: The column name in the destination_table (defaults to "id")
+     *  - on_update: action on update. example: RESTRICT, CASCADE
+     *  - on_delete: action on delete. example: RESTRICT, CASCADE
+     * @return boolean
+     */
+
+    public function add_foreign_key($orig_table_name, $dest_table_name, $options = array())
+    {
+        return $this->_adapter->add_foreign_key($orig_table_name, $dest_table_name, $options);
+    }
+
+    /**
+     * Removes a foreign key
+     * @param unknown $table_name
+     * @param unknown $key_name
+     */
+
+    public function remove_foreign_key($table_name, $key_name)
+    {
+        return $this->_adapter->remove_foreign_key($table_name, $key_name);
+    }
+
+    /**
      * Create a table
      * @param string $table_name the name of the table
      * @param array|string $options

--- a/tests/unit/BaseMigrationTest.php
+++ b/tests/unit/BaseMigrationTest.php
@@ -125,6 +125,6 @@ create table `adminsession` (
 
         // cleanup
         $base->execute("DROP TABLE `admin`; DROP TABLE `adminsession`; DROP TABLE `demo`;");
-        
+
     }
 }

--- a/tests/unit/MySQLTableDefinitionTest.php
+++ b/tests/unit/MySQLTableDefinitionTest.php
@@ -39,6 +39,9 @@ class MySQLTableDefinitionTest extends PHPUnit_Framework_TestCase
         if ($this->adapter->has_table('users',true)) {
             $this->adapter->drop_table('users');
         }
+        if ($this->adapter->has_table('reservations',true)) {
+            $this->adapter->drop_table('reservations');
+        }
     }
 
     /*
@@ -211,4 +214,39 @@ class MySQLTableDefinitionTest extends PHPUnit_Framework_TestCase
         $col = $this->adapter->column_info("users", "id");
         $this->assertEquals(null, $col);
     }
+
+    /**
+     * test that we can generate a table w/o a primary key
+     */
+    public function test_create_foreign_key()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $t1 = $bm->create_table('users', array('id' => false));
+        $t1->column('id', 'integer', array('unsigned' => true, 'primary_key' => true, 'auto_increment' => true));
+        $t1->finish();
+
+        $t2 = $bm->create_table('reservations', array('id' => false));
+        $t2->column('id', 'integer', array('unsigned' => true, 'primary_key' => true, 'auto_increment' => true));
+        $t2->column('user_id', 'integer', array('unsigned' => true));
+        $t2->finish();
+
+        $bm->add_foreign_key('reservations', 'users');
+
+        $result = $bm->select_one("select TABLE_NAME,COLUMN_NAME,CONSTRAINT_NAME, REFERENCED_TABLE_NAME,REFERENCED_COLUMN_NAME
+                FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+                WHERE TABLE_NAME = 'reservations' AND REFERENCED_TABLE_NAME = 'users' AND COLUMN_NAME = 'user_id' AND REFERENCED_COLUMN_NAME = 'id';");
+
+        $key = null;
+        if (is_array($result) && isset($result['CONSTRAINT_NAME'])) {
+            $key = $result['CONSTRAINT_NAME'];
+        }
+
+        $this->assertEquals('reservations_user_id_fk', $key);
+
+        $bm->drop_table('reservations');
+        $bm->drop_table('users');
+
+
+    }
+
 }


### PR DESCRIPTION
Add foreign key functionality.

Note: the add_foreign_key functionality has only been added for the MySql adaptor.

Example of use: `$this->add_foreign_key('api_keys', 'users');`
